### PR TITLE
writable trait + hadoop.io.Text implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ tests:
 release:
 	cargo build --all-targets --release
 
+doc:
+	cargo doc
+
 clean:
 	cargo clean
 
-all: clean lint tests release
+all: clean lint tests doc release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,17 @@
 //! }
 //! ```
 
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces
+)]
+
 extern crate byteorder;
 extern crate bzip2;
 extern crate flate2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub struct Header {
 // modules
 mod compress;
 mod errors;
+mod text;
 mod util;
 
 pub mod reader;
@@ -64,6 +65,7 @@ pub mod reader;
 // exports
 pub use compress::{Codec, CompressionType};
 pub use reader::*;
+pub use text::*;
 
 #[cfg(test)]
 pub mod tests;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,6 +5,7 @@ use compress;
 use compress::CompressionType;
 use errors::{Error, Result};
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::io;
 use std::io::prelude::*;
 use std::io::BufReader;
@@ -15,24 +16,36 @@ use {ByteString, Header};
 const MAGIC: &str = "SEQ";
 const SYNC_SIZE: usize = 16;
 
+pub trait Writable {
+    fn read(buf: &mut [u8]) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+impl Writable for Vec<u8> {
+    fn read(buf: &mut [u8]) -> Result<Self> {
+        Ok(buf.to_vec())
+    }
+}
+
 /// Provides a streaming interface fronted by an Iterator
 /// Only buffers when `CompressionType::Block` is used.
 #[derive(Debug)]
-pub struct Reader<R: io::Read> {
+pub struct Reader<R: io::Read, K: Writable, V: Writable> {
     /// Sequencefile header
     pub header: Header,
     reader: BufReader<R>,
-    block_buffer: Vec<(ByteString, ByteString)>,
+    block_buffer: Vec<(K, V)>,
     is_error: bool,
 }
 
-impl<R: io::Read> Reader<R> {
+impl<R: io::Read, K: Writable, V: Writable> Reader<R, K, V> {
     /// Create a new Reader from an io::Read
     ///
     /// # Failures
     /// Returns an `Error` if sequencefile header is malformed, e.g. unsupported version or
     /// invalid compression algorithm
-    pub fn new(r: R) -> Result<Reader<R>> {
+    pub fn new(r: R) -> Result<Reader<R, K, V>> {
         let mut br = BufReader::new(r);
 
         let header = read_header(&mut br)?;
@@ -119,10 +132,10 @@ fn read_header<R: io::Read>(reader: &mut R) -> Result<Header> {
     })
 }
 
-impl<R: io::Read> Iterator for Reader<R> {
-    type Item = Result<(ByteString, ByteString)>;
+impl<R: io::Read, K: Writable, V: Writable> Iterator for Reader<R, K, V> {
+    type Item = Result<(K, V)>;
 
-    fn next(&mut self) -> Option<Result<(ByteString, ByteString)>> {
+    fn next(&mut self) -> Option<Result<(K, V)>> {
         if self.is_error {
             return None;
         }
@@ -141,7 +154,9 @@ impl<R: io::Read> Iterator for Reader<R> {
     }
 }
 
-fn next_element<R: io::Read>(reader: &mut Reader<R>) -> Result<(ByteString, ByteString)> {
+fn next_element<R: io::Read, K: Writable, V: Writable>(
+    reader: &mut Reader<R, K, V>,
+) -> Result<(K, V)> {
     if reader.block_buffer.is_empty() || reader.header.compression_type != CompressionType::Block {
         let mut last_sync_marker = [0; SYNC_SIZE];
         let mut kv_length = reader.reader.read_i32::<BigEndian>()? as i64;
@@ -159,11 +174,7 @@ fn next_element<R: io::Read>(reader: &mut Reader<R>) -> Result<(ByteString, Byte
         }
 
         if reader.header.compression_type != CompressionType::Block {
-            let (key, value) = read_kv(kv_length as isize, &reader.header, &mut reader.reader)?;
-            if key.len() + value.len() != kv_length as usize {
-                panic!("inconsistent read");
-            }
-            return Ok((key, value));
+            return read_kv(kv_length as isize, &reader.header, &mut reader.reader);
         }
     }
 
@@ -211,7 +222,9 @@ fn next_element<R: io::Read>(reader: &mut Reader<R>) -> Result<(ByteString, Byte
                 let mut v = vec![0; len]; //todo: reuse
                 c.read_exact(&mut v)?;
 
-                reader.block_buffer.push((keys.remove(0), v));
+                reader
+                    .block_buffer
+                    .push((K::read(&mut keys.remove(0))?, V::read(&mut v)?));
             }
         }
 
@@ -226,11 +239,11 @@ fn next_element<R: io::Read>(reader: &mut Reader<R>) -> Result<(ByteString, Byte
     }
 }
 
-fn read_kv<R: io::Read>(
+fn read_kv<R: io::Read, K: Writable, V: Writable>(
     kv_length: isize,
     header: &Header,
     reader: &mut R,
-) -> Result<(Vec<u8>, Vec<u8>)> {
+) -> Result<(K, V)> {
     let k_length = reader.read_i32::<BigEndian>()? as usize;
 
     let k_start = 0;
@@ -255,20 +268,20 @@ fn read_kv<R: io::Read>(
     let mut buffer = vec![0; kv_length as usize];
     reader.read_exact(&mut buffer)?;
 
-    let key = buffer[k_start..k_end].to_vec();
+    let mut key = buffer[k_start..k_end].to_vec();
 
     if header.compression_type == CompressionType::Record {
         if let Some(ref codec) = header.compression_codec {
-            let decompressed = compress::decompressor(codec, &buffer[v_start..v_end])?;
+            let mut decompressed = compress::decompressor(codec, &buffer[v_start..v_end])?;
 
-            Ok((key, decompressed))
+            Ok((K::read(&mut key)?, V::read(&mut decompressed)?))
         } else {
             panic!("WAT")
         }
     } else {
-        let value = buffer[v_start..v_end].to_vec();
+        let mut value = buffer[v_start..v_end].to_vec();
 
-        Ok((key, value))
+        Ok((K::read(&mut key)?, V::read(&mut value)?))
     }
 }
 
@@ -289,4 +302,39 @@ fn read_buf<R: io::Read>(reader: &mut R) -> Result<Vec<u8>> {
     reader.read_exact(&mut key_buf)?;
 
     Ok(key_buf)
+}
+
+pub fn read_vint<R: io::Read>(reader: &mut R) -> Result<i32> {
+    let first_byte = reader.read_i8()?;
+
+    let len = decode_vint_size(first_byte);
+    if len == 1 {
+        return Ok(first_byte as i32);
+    }
+    let mut i: i64 = 0;
+    for _ in 0..len - 1 {
+        let b = reader.read_u8()?;
+        i <<= 8;
+        i |= b as i64;
+    }
+
+    if is_negative_vint(first_byte) {
+        return Ok((i ^ -1).try_into().unwrap());
+    }
+
+    Ok(i.try_into().unwrap())
+}
+
+fn is_negative_vint(value: i8) -> bool {
+    value < -120 || (value >= -112 && value < 0)
+}
+
+fn decode_vint_size(value: i8) -> i32 {
+    if value >= -112 {
+        return 1;
+    } else if value < -120 {
+        return (-119 - value).into();
+    }
+
+    (-111 - value).into()
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -16,7 +16,10 @@ use {ByteString, Header};
 const MAGIC: &str = "SEQ";
 const SYNC_SIZE: usize = 16;
 
+/// Basic trait mapping hadoop.io.Writable abstract class
+/// Keys and Values types should implement this type to provide automatic deserialization
 pub trait Writable {
+    /// reads byte from buffer and converts to a concrete instance of Writable
     fn read(buf: &mut [u8]) -> Result<Self>
     where
         Self: Sized;
@@ -304,6 +307,10 @@ fn read_buf<R: io::Read>(reader: &mut R) -> Result<Vec<u8>> {
     Ok(key_buf)
 }
 
+/// Reads a vint (variable bit size int)
+///
+/// # Failures
+/// Returns an `Error` if reader is too small
 pub fn read_vint<R: io::Read>(reader: &mut R) -> Result<i32> {
     let first_byte = reader.read_i8()?;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -55,18 +55,7 @@ fn read_checks_magic() {
     };
 }
 
-// #[test]
-// fn read_webgraph_nodes() {
-//     let reader = reader_for("test_data/nodes.seq").expect("cannot open sequence file");
-//     println!("{}", reader.header.key_class);
-//     println!("{}", reader.header.value_class);
-//     let mut output = File::create("keys.txt").expect("cannot open output file");
-//     for (key, _) in reader.flatten() {
-//         writeln!(output, "{:?}", OsStr::from_bytes(&key)).unwrap();
-//     }
-// }
-
-fn reader_for(filename: &str) -> Result<reader::Reader<File>> {
+fn reader_for(filename: &str) -> Result<reader::Reader<File, Vec<u8>, Vec<u8>>> {
     let path = Path::new(filename);
     let file = File::open(&path)?;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -55,6 +55,17 @@ fn read_checks_magic() {
     };
 }
 
+// #[test]
+// fn read_webgraph_nodes() {
+//     let reader = reader_for("test_data/nodes.seq").expect("cannot open sequence file");
+//     println!("{}", reader.header.key_class);
+//     println!("{}", reader.header.value_class);
+//     let mut output = File::create("keys.txt").expect("cannot open output file");
+//     for (key, _) in reader.flatten() {
+//         writeln!(output, "{:?}", OsStr::from_bytes(&key)).unwrap();
+//     }
+// }
+
 fn reader_for(filename: &str) -> Result<reader::Reader<File>> {
     let path = Path::new(filename);
     let file = File::open(&path)?;

--- a/src/text.rs
+++ b/src/text.rs
@@ -5,16 +5,19 @@ use std::borrow::Cow;
 use std::io::Read;
 
 /// hadoop.io.Text
+#[derive(Debug)]
 pub struct Text {
     len: i32,
     buf: Vec<u8>,
 }
 
 impl Text {
+    /// Converts to String
     pub fn to_string(&self) -> Cow<str> {
         String::from_utf8_lossy(&self.buf)
     }
 
+    /// Tells if instance is an empty string or not
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,31 @@
+use crate::errors::Result;
+use crate::{read_vint, Writable};
+
+use std::borrow::Cow;
+use std::io::Read;
+
+/// hadoop.io.Text
+pub struct Text {
+    len: i32,
+    buf: Vec<u8>,
+}
+
+impl Text {
+    pub fn to_string(&self) -> Cow<str> {
+        String::from_utf8_lossy(&self.buf)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl Writable for Text {
+    fn read(input: &mut [u8]) -> Result<Self> {
+        let mut reader = std::io::Cursor::new(input);
+        let len = read_vint(&mut reader)?;
+        let mut buf = vec![0; len as usize];
+        reader.read_exact(&mut buf)?;
+        Ok(Self { len, buf })
+    }
+}


### PR DESCRIPTION
bugfix for uncompressed streams
writable trait + default implementation for Vec<u8>
hadoop.io.Text implementation (to read most of keys)
unfortunately can't commit data files I used to UT as it's company code